### PR TITLE
chore: configure minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,4 @@ Modpow_kotlinVersion=1.7.0
 Modpow_compileSdkVersion=28
 Modpow_buildToolsVersion=28.0.3
 Modpow_targetSdkVersion=28
+Modpow_minSdkVersion=16


### PR DESCRIPTION
minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-android:0.72.4]